### PR TITLE
Fix constructor to be closer to the Date constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var date_with_offset=/^\d\d\d\d-\d\d-\d\d \d\d\:\d\d\:\d\d(\.\d\d\d)? (Z|(\-|\+|
 var date_rfc_2822_regex=/^\d\d-\w\w\w-\d\d\d\d \d\d\:\d\d\:\d\d (\+|-)\d\d\d\d$/;
 var local_date_regex=/^\d\d\d\d-\d\d-\d\d \d\d\:\d\d\:\d\d(\.\d\d\d)?$/;
 
-function MockDate(param, month, date, hours, minutes, seconds, milliseconds) {
+function MockDate(param) {
   if (arguments.length === 1) {
     if (param instanceof MockDate) {
       this.d = new _Date(param.d);
@@ -33,9 +33,8 @@ function MockDate(param, month, date, hours, minutes, seconds, milliseconds) {
       assert.ok(false, 'Unhandled type passed to MockDate constructor: ' + typeof param);
     }
   } else {
-    var year = param;
     this.d = new _Date();
-    this.fromLocal(new _Date(_Date.UTC(year, month, date, hours, minutes, seconds, milliseconds)));
+    this.fromLocal(new _Date(_Date.UTC.apply(null, arguments)));
   }
 }
 

--- a/tests/test-constructors.js
+++ b/tests/test-constructors.js
@@ -45,3 +45,7 @@ assert.equal(1495821155869, new Date('2017-05-26 10:52:35.869 -07:00').getTime()
 assert.equal(1495821155000, new Date('2017-05-26T17:52:35').getTime());
 assert.equal(1495821155000, new Date('2017-05-26 17:52:35 +00:00').getTime());
 assert.equal(1495821155000, new Date('2017-05-26 10:52:35 -07:00').getTime());
+
+//////////////////////////////////////////////////////////////////////////
+// Test some generic properties about the date object
+assert.equal(new Date(2017, 5).getTime(), new Date(2017, 5, 1, 0, 0, 0, 0).getTime());


### PR DESCRIPTION
The `Date` constructor for multiple arguments actually has optional params past `month` - i.e. `new Date(year, month[, date[, hours[, minutes[, seconds[, milliseconds]]]]]);` [(see here)](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date)

This PR adds support for those parameters being optional