### PR TITLE
pass valueOf to Date's valueOf, fixes #12 #13

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,6 +152,10 @@ MockDate.prototype.toString = MockDate.prototype.toLocaleString = function () {
   return 'Mockday ' + this.d.toISOString() + ' GMT-0' + this.calcTZO() + '00 (MockDate)';
 };
 
+MockDate.prototype.valueOf = function () {
+  return _Date.prototype.valueOf.call(this.d);
+}
+
 MockDate.now = _Date.now;
 
 MockDate.UTC = _Date.UTC;


### PR DESCRIPTION
I ran into a similar issue as described in #12 and #13 (a library that was doing a cast like `+ (new Date())`). Implementing valueOf should fix it as well as #12 and #13.