### PR TITLE
Specific global can be passed on register and unregister

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,13 +164,13 @@ MockDate.UTC = _Date.UTC;
 // 'toLocaleTimeString',
 // 'toTimeString',
 
-function register(new_timezone) {
+function register(new_timezone, glob = global) {
   timezone = new_timezone || 'US/Pacific';
-  global.Date = MockDate;
+  glob.Date = MockDate;
 }
 exports.register = register;
 
-function unregister() {
-  global.Date = _Date;
+function unregister(glob = global) {
+  glob.Date = _Date;
 }
 exports.unregister = unregister;


### PR DESCRIPTION
It's going to be really useful to be able to somehow get MockDate from a module or specify global on `register` and `unregister` functions as in pull request.

I'm using your lib in Cypress tests and there is a have different global to work with.