### PR TITLE
feat: add support for parse function

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ MockDate.prototype.setYear = function (yr) {
 };
 
 MockDate.parse = function (dateString) {
-  return _Date.parse(dateString);
+  return new MockDate(dateString).getTime();
 }
 
 MockDate.prototype.getTimezoneOffset = function () {

--- a/index.js
+++ b/index.js
@@ -144,6 +144,10 @@ MockDate.prototype.setYear = function (yr) {
   return this.setFullYear(yr);
 };
 
+MockDate.parse = function (dateString) {
+  return _Date.parse(dateString);
+}
+
 MockDate.prototype.getTimezoneOffset = function () {
   return this.calcTZO() * 60;
 };


### PR DESCRIPTION
Because it was missing in timezone-mock, parse was removed from MockDate and threw errors in Jest tests.