### PR TITLE
Add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+interface DateHoldingGlobal {
+  Date: typeof Date;
+}
+
+export type TimeZone =
+  'Brazil/East' |
+  'Europe/London' |
+  'US/Eastern' |
+  'US/Pacific' |
+  'UTC';
+
+export function register(zone: TimeZone, glob?: DateHoldingGlobal): void;
+export function unregister(glob?: DateHoldingGlobal): void;
+export const _Date: typeof Date;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.6",
   "description": "A JavaScript library to mock the local timezone.",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/Jimbly/timezone-mock.git"


### PR DESCRIPTION
I realise this project isn't targeting Typescript explicitly, but supporting it out-of-the-box is a pretty small change, so I thought I'd propose it.

The alternative is for this to live in the [@types project](https://github.com/DefinitelyTyped/DefinitelyTyped), but that seems a rather high overhead. It is also possible for each user of the library to provide their own types, but that means a lot of reinventing the wheel.

Since the whole point here is to mimic the `Date` API, this should be very low maintenance. The only bit which would need updating is the list of supported timezones (which could be replaced with a general `string` if preferred, in which case this file would probably never need to be touched again).

---

Typescript users are able to use the library in several ways:

```typescript
import timezoneMock from 'timezone-mock';

timezoneMock.register('UTC');
// ...
timezoneMock.unregister();
// ...
const realDate = new timezoneMock._Date();
// ...

const myFakeGlobal = { Date };
timezoneMock.register('UTC', myFakeGlobal);

const myFakeBrokenGlobal = { Date: 0 };
timezoneMock.register('UTC', myFakeBrokenGlobal); // <-- compile error
```

```typescript
import { register, unregister } from 'timezone-mock';

register('UTC');
register('oops'); // <-- compile error
// ...
unregister();
```

```typescript
import timezoneMock, { TimeZone } from 'timezone-mock';

function wrap(timeZone: TimeZone) {
  timezoneMock.register(timeZone);
  // ...
  timezoneMock.unregister();
}

wrap('UTC');
wrap('oops'); // <-- compile error
```