### PR TITLE
Hkasemir/update local regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var HOUR = 60 * 60 * 1000;
 var date_iso_8601_regex=/^\d\d\d\d(-\d\d(-\d\d(T\d\d\:\d\d\:\d\d(\.\d\d\d)?(Z|[+-]\d\d\:?\d\d))?)?)?$/;
 var date_with_offset=/^\d\d\d\d-\d\d-\d\d \d\d\:\d\d\:\d\d(\.\d\d\d)? (Z|(\-|\+|)\d\d\:\d\d)$/;
 var date_rfc_2822_regex=/^\d\d-\w\w\w-\d\d\d\d \d\d\:\d\d\:\d\d (\+|-)\d\d\d\d$/;
-var local_date_regex=/^\d\d\d\d-\d\d-\d\d[T ]\d\d\:\d\d\:\d\d(\.\d\d\d)?$/;
+var local_date_regex=/^\d\d\d\d-\d\d-\d\d[T ]\d\d\:\d\d(\:\d\d(\.\d\d\d)?)?$/;
 
 function MockDate(param) {
   if (arguments.length === 0) {

--- a/tests/test-constructors.js
+++ b/tests/test-constructors.js
@@ -54,6 +54,10 @@ test('date constructors as used by local timezone mode in node-mysql (local stri
   //   This behavior changed on Node v8.0.0
   assert.equal(1420104225678, new Date('2015-01-01T01:23:45.678').getTime());
   assert.equal(1420104225000, new Date('2015-01-01T01:23:45').getTime());
+
+  // supports variation of ECMAscript spec for THH:mm
+  // https://www.ecma-international.org/ecma-262/#sec-date-time-string-format
+  assert.equal(1414915200000, new Date('2014-11-02T01:00').getTime());
 });
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When testing with latest versions of d3, there is an issue with a date constructor that timezone-mock does not support:
https://github.com/d3/d3-dsv/blob/master/src/autoType.js#L20

This results in the following error:
```
AssertionError [ERR_ASSERTION]: Unhandled date format passed to MockDate constructor: 2019-01-01T00:00
```

as `2019-01-01T00:00` is a supported format in the [ECMAscript spec](https://www.ecma-international.org/ecma-262/#sec-date-time-string-format), I'd like to add support to timezone-mock, so I can keep both dependencies.

Thanks!
