### PR TITLE
add support for null constructor; fix tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,10 +32,8 @@ function MockDate(param) {
       } else {
         assert.ok(false, 'Unhandled date format passed to MockDate constructor: ' + param);
       }
-    } else if (typeof param === 'number') {
+    } else if (typeof param === 'number' || param === null || param === undefined) {
       this.d = new _Date(param);
-    } else if (typeof param === 'undefined') {
-      this.d = new _Date();
     } else {
       assert.ok(false, 'Unhandled type passed to MockDate constructor: ' + typeof param);
     }
@@ -75,6 +73,7 @@ function passthrough(fn) {
 }
 function localgetter(fn) {
   MockDate.prototype[fn] = function () {
+    if (Number.isNaN(this.d.getTime())) return NaN;
     var d = new _Date(this.d.getTime() - this.calcTZO() * HOUR);
     return d['getUTC' + fn.slice(3)]();
   };
@@ -152,6 +151,7 @@ MockDate.parse = function (dateString) {
 }
 
 MockDate.prototype.getTimezoneOffset = function () {
+  if (Number.isNaN(this.d.getTime())) return NaN;
   return this.calcTZO() * 60;
 };
 
@@ -160,6 +160,7 @@ MockDate.prototype.toString = MockDate.prototype.toLocaleString = function () {
     // someone, like util.inspect, calling Date.prototype.toString.call(foo)
     return _Date.prototype.toString.call(this);
   }
+  if (Number.isNaN(this.d.getTime())) return new _Date('').toString();
   return 'Mockday ' + this.d.toISOString() + ' GMT-0' + this.calcTZO() + '00 (MockDate)';
 };
 
@@ -168,11 +169,11 @@ MockDate.now = _Date.now;
 MockDate.UTC = _Date.UTC;
 
 MockDate.prototype.toDateString = function () {
+  if (Number.isNaN(this.d.getTime())) return new _Date('').toDateString();
   return `${ weekDays[this.getDay()] } ${ months[this.getMonth()] } ${ this.getDate().toString().padStart(2, '0') } ${ this.getFullYear() }`;
 };
 
 // TODO:
-// 'toDateString',
 // 'toLocaleDateString',
 // 'toLocaleTimeString',
 // 'toTimeString',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "timezone-mock",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 1
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "timezone-mock",
-  "version": "1.0.9",
+  "version": "1.0.11",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timezone-mock",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A JavaScript library to mock the local timezone.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/test-constructors.js
+++ b/tests/test-constructors.js
@@ -3,6 +3,8 @@
 var assert = require('assert');
 var timezone_mock = require('..');
 
+timezone_mock.register();
+
 var test = global.test || ((name, tst) => {
   console.log('TEST:', name, '...');
   tst();
@@ -12,9 +14,15 @@ var test = global.test || ((name, tst) => {
 //////////////////////////////////////////////////////////////////////////
 test('"simple" date constructors', function() {
   assert.ok(new Date());
+  assert.ok(new Date(null));
+
   assert.ok(new Date(''));
   assert.ok(new Date('').toString() === 'Invalid Date');
   assert.ok(Number.isNaN(new Date('').getHours()));
+
+  var invalidDateMadeValid = new Date('')
+  assert.ok(invalidDateMadeValid.setTime(12345) === 12345)
+  assert.ok(!Number.isNaN(invalidDateMadeValid.getHours()));
 });
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Unfortunately the `"simple" date constructors` tests weren't testing the library (no register call). This PR fixes that as well.