### PR TITLE
Updates date_iso_8601_regex to support missing UTC format

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var months = ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul', 'Aug', 'Sept', 'Oct', 'N
 
 var HOUR = 60 * 60 * 1000;
 
-var date_iso_8601_regex = /^\d\d\d\d(-\d\d(-\d\d(T\d\d:\d\d:\d\d(\.\d\d\d)?(Z|[+-]\d\d:?\d\d))?)?)?$/;
+var date_iso_8601_regex = /^\d\d\d\d(-\d\d(-\d\d(T\d\d:\d\d:\d\d(\.\d\d\d)?(\d\d\d)?(Z|[+-]\d\d:?\d\d))?)?)?$/;
 var date_with_offset = /^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d\d\d)? (Z|(-|\+|)\d\d:\d\d)$/;
 var date_rfc_2822_regex = /^\d\d-\w\w\w-\d\d\d\d \d\d:\d\d:\d\d (\+|-)\d\d\d\d$/;
 var local_date_regex = /^\d\d\d\d-\d\d-\d\d[T ]\d\d:\d\d(:\d\d(\.\d\d\d)?)?$/;

--- a/tests/test-constructors.js
+++ b/tests/test-constructors.js
@@ -72,6 +72,7 @@ test('date constructors as used by local timezone mode in node-mysql (local stri
 //////////////////////////////////////////////////////////////////////////
 test('UTC/non-local timezone constructors', function() {
   assert.equal(1495821155869, new Date('2017-05-26T17:52:35.869Z').getTime());
+  assert.equal(1495821155869, new Date('2017-05-26T17:52:35.869000Z').getTime());
   assert.equal(1495821155869, new Date('2017-05-26 17:52:35.869 Z').getTime());
   assert.equal(1495821155869, new Date('2017-05-26 17:52:35.869 -00:00').getTime());
   assert.equal(1495821155869, new Date('2017-05-26 17:52:35.869 +00:00').getTime());


### PR DESCRIPTION
The missing format includes 6 digits after seconds. Example: 2017-05-26T17:52:35.869000Z