### PR TITLE
Add the ability to supply a fallback function which gets called when …

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ API
 the specified timezone.  Defaults to 'US/Pacific' if no timezone is specified.
 * `timezone_mock.unregister()` - Return to normal Date object behavior
 * `timezone_mock._Date` - access to the original Date object for testing
+* `timezone_mock.options({ fallbackFn })` - Option to provide a fallback function when `timezone-mock` fails to parse.
 
 Supported Timezones
 ===================

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,7 @@
+interface Options {
+  fallbackFn: (date: any) => typeof Date;
+}
+
 interface DateHoldingGlobal {
   Date: typeof Date;
 }
@@ -10,6 +14,7 @@ export type TimeZone =
   'US/Pacific' |
   'UTC';
 
+export function options(options: Options): void;
 export function register(zone: TimeZone, glob?: DateHoldingGlobal): void;
 export function unregister(glob?: DateHoldingGlobal): void;
 export const _Date: typeof Date;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ exports.tzdata = tzdata;
 var _Date = Date;
 exports._Date = _Date;
 
-var MockDateOptions = {};
+var mockDateOptions = {};
 
 var timezone;
 
@@ -35,15 +35,15 @@ function MockDate(param) {
       } else if (param.match(local_date_regex)) {
         this.d = new _Date();
         this.fromLocal(new _Date(param.replace(' ', 'T') + 'Z'));
-      } else if (MockDateOptions.fallbackFn) {
-        this.d = MockDateOptions.fallbackFn(param);
+      } else if (mockDateOptions.fallbackFn) {
+        this.d = mockDateOptions.fallbackFn(param);
       } else {
         assert.ok(false, 'Unhandled date format passed to MockDate constructor: ' + param);
       }
     } else if (typeof param === 'number' || param === null || param === undefined) {
       this.d = new _Date(param);
-    } else if (MockDateOptions.fallbackFn) {
-      this.d = MockDateOptions.fallbackFn(param);
+    } else if (mockDateOptions.fallbackFn) {
+      this.d = mockDateOptions.fallbackFn(param);
     } else {
       assert.ok(false, 'Unhandled type passed to MockDate constructor: ' + typeof param);
     }
@@ -219,7 +219,7 @@ MockDate.prototype.toDateString = function () {
 // 'toTimeString',
 
 function options(opts) {
-  MockDateOptions = opts || {};
+  mockDateOptions = opts || {};
 }
 exports.options = options;
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ exports.tzdata = tzdata;
 var _Date = Date;
 exports._Date = _Date;
 
+var MockDateOptions = {};
+
 var timezone;
 
 var weekDays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -33,11 +35,15 @@ function MockDate(param) {
       } else if (param.match(local_date_regex)) {
         this.d = new _Date();
         this.fromLocal(new _Date(param.replace(' ', 'T') + 'Z'));
+      } else if (MockDateOptions.fallbackFn) {
+        this.d = MockDateOptions.fallbackFn(param)
       } else {
         assert.ok(false, 'Unhandled date format passed to MockDate constructor: ' + param);
       }
     } else if (typeof param === 'number' || param === null || param === undefined) {
       this.d = new _Date(param);
+    } else if (MockDateOptions.fallbackFn) {
+      this.d = MockDateOptions.fallbackFn(param)
     } else {
       assert.ok(false, 'Unhandled type passed to MockDate constructor: ' + typeof param);
     }
@@ -211,6 +217,11 @@ MockDate.prototype.toDateString = function () {
 // 'toLocaleDateString',
 // 'toLocaleTimeString',
 // 'toTimeString',
+
+function options(options) {
+  MockDateOptions = options || {}
+}
+exports.options = options;
 
 function register(new_timezone, glob) {
   if (!glob) {

--- a/index.js
+++ b/index.js
@@ -36,14 +36,14 @@ function MockDate(param) {
         this.d = new _Date();
         this.fromLocal(new _Date(param.replace(' ', 'T') + 'Z'));
       } else if (MockDateOptions.fallbackFn) {
-        this.d = MockDateOptions.fallbackFn(param)
+        this.d = MockDateOptions.fallbackFn(param);
       } else {
         assert.ok(false, 'Unhandled date format passed to MockDate constructor: ' + param);
       }
     } else if (typeof param === 'number' || param === null || param === undefined) {
       this.d = new _Date(param);
     } else if (MockDateOptions.fallbackFn) {
-      this.d = MockDateOptions.fallbackFn(param)
+      this.d = MockDateOptions.fallbackFn(param);
     } else {
       assert.ok(false, 'Unhandled type passed to MockDate constructor: ' + typeof param);
     }
@@ -218,8 +218,8 @@ MockDate.prototype.toDateString = function () {
 // 'toLocaleTimeString',
 // 'toTimeString',
 
-function options(options) {
-  MockDateOptions = options || {}
+function options(opts) {
+  MockDateOptions = opts || {};
 }
 exports.options = options;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "timezone-mock",
-  "version": "1.0.17",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/test-constructors.js
+++ b/tests/test-constructors.js
@@ -107,3 +107,27 @@ test('Make sure month May exists', function() {
   assert.equal(new Date(1598964466381).toDateString(), 'Tue Sept 01 2020');
   timezone_mock.unregister();
 });
+
+//////////////////////////////////////////////////////////////////////////
+test('option to use a fallback function when failing to parse (issue #24)', function() {
+  timezone_mock.unregister();
+  var _Date = Date
+  timezone_mock.options({
+    fallbackFn: (date) => new _Date(date)
+  })
+  timezone_mock.register('UTC');
+  assert.equal(new Date('Fri, 26 Jul 2019 10:32:24 GMT').toDateString(), 'Fri Jul 26 2019');
+  timezone_mock.unregister();
+
+  // How can we reset options?
+  timezone_mock.options()
+  timezone_mock.register('UTC');
+  try {
+    assert.equal(new Date('Fri, 26 Jul 2019 10:32:24 GMT').toDateString(), 'Fri Jul 26 2019');
+    assert.error('We shouldn\'t have made it here!')
+  }catch(err) {
+    // Expected
+  }finally{
+    timezone_mock.unregister();
+  }
+});

--- a/tests/test-constructors.js
+++ b/tests/test-constructors.js
@@ -122,12 +122,13 @@ test('option to use a fallback function when failing to parse (issue #24)', func
   // How can we reset options?
   timezone_mock.options();
   timezone_mock.register('UTC');
+  var got_error = false;
   try {
     assert.equal(new Date('Fri, 26 Jul 2019 10:32:24 GMT').toDateString(), 'Fri Jul 26 2019');
-    assert.error('We shouldn\'t have made it here!');
   } catch (err) {
     // Expected
-  } finally {
-    timezone_mock.unregister();
+    got_error = true;
   }
+  assert.equal(got_error, true);
+  timezone_mock.unregister();
 });

--- a/tests/test-constructors.js
+++ b/tests/test-constructors.js
@@ -111,23 +111,23 @@ test('Make sure month May exists', function() {
 //////////////////////////////////////////////////////////////////////////
 test('option to use a fallback function when failing to parse (issue #24)', function() {
   timezone_mock.unregister();
-  var _Date = Date
+  var _Date = Date;
   timezone_mock.options({
     fallbackFn: (date) => new _Date(date)
-  })
+  });
   timezone_mock.register('UTC');
   assert.equal(new Date('Fri, 26 Jul 2019 10:32:24 GMT').toDateString(), 'Fri Jul 26 2019');
   timezone_mock.unregister();
 
   // How can we reset options?
-  timezone_mock.options()
+  timezone_mock.options();
   timezone_mock.register('UTC');
   try {
     assert.equal(new Date('Fri, 26 Jul 2019 10:32:24 GMT').toDateString(), 'Fri Jul 26 2019');
-    assert.error('We shouldn\'t have made it here!')
-  }catch(err) {
+    assert.error('We shouldn\'t have made it here!');
+  } catch (err) {
     // Expected
-  }finally{
+  } finally {
     timezone_mock.unregister();
   }
 });


### PR DESCRIPTION
…`timezone-mock` fails to parse.