### PR TITLE
Added support for all offsets from GMT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.sublime-workspace
+out.txt

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Currently supported timezones are:
 * Europe/London
 * Australia/Adelaide
 
-I found that testing on these three were enough to ensure code worked in
+I found that testing on these were enough to ensure code worked in
 all timezones (important factor is to test on a timezone with Daylight Saving
 Time if your local timezone does not).  Brazil/East has the unique characteristic
 of having the DST transition happen right at midnight, so code that sets a Date
@@ -72,6 +72,43 @@ object to midnight on a particular day and then does operations on that Date
 object is especially vulnerable in that timezone.  Europe/London is included as
 a timezone that is a positive offset from UTC, and Australia/Adelaide as one that
 has a large positive and non-integral offset (+9.5/+10.5).
+
+Supported GMT Offsets
+=====================
+Currently supported GMT offsets are:
+* Etc/GMT+12
+* Etc/GMT+11
+* Etc/GMT+10
+* Etc/GMT+9
+* Etc/GMT+8
+* Etc/GMT+7
+* Etc/GMT+6
+* Etc/GMT+5
+* Etc/GMT+4
+* Etc/GMT+3
+* Etc/GMT+2
+* Etc/GMT+1
+* Etc/GMT+0
+* Etc/GMT
+* Etc/GMT-0
+* Etc/GMT-1
+* Etc/GMT-2
+* Etc/GMT-3
+* Etc/GMT-4
+* Etc/GMT-5
+* Etc/GMT-6
+* Etc/GMT-7
+* Etc/GMT-8
+* Etc/GMT-9
+* Etc/GMT-10
+* Etc/GMT-11
+* Etc/GMT-12
+* Etc/GMT-13
+* Etc/GMT-14
+
+GMT offsets can be used to test if UTC times fall on particular local calendar days.
+Note: `Etc/GMT+0`, `Etc/GMT`, and `Etc/GMT-0` all represent the same offset and are
+equivalent to the `UTC` time zone.
 
 Status
 ======

--- a/import.js
+++ b/import.js
@@ -81,6 +81,12 @@ for (let ii = 0; ii < tzh_ttisgmtcnt; ++ii) {
 let cuttoff = new Date('2038').getTime() / 1000; // Things get weird after this in the Linux data, ignore it
 transitions = transitions.filter((trans) => trans.time < cuttoff);
 
+// add transitions for the first and last timestamps if the time zone doesn't have DST transitions
+if (!transitions.length) {
+  transitions.push({ time: 0, which: 0 });
+  transitions.push({ time: Infinity, which: 0 });
+}
+
 let named = {};
 let out = {
   names: [],
@@ -96,13 +102,16 @@ for (let ii = 0; ii < transitions.length; ++ii) {
     named[offs] = true;
   }
 }
+
 if (out.transitions[0]) {
   // Assume alternating and start at the other
   out.transitions.splice(0, 0, 0, out.transitions[3]);
 }
 
+const zoneName = process.argv[2].split('zoneinfo/')[1];
 // console.log(out);
-console.log('  {');
+console.log('');
+console.log(`  '${zoneName}': {`);
 console.log(`    names: [${out.names.map((v) => (typeof v === 'string' ? `'${v}'` : v)).join(', ')}],`);
 console.log('    transitions: [');
 for (let ii = 0; ii < out.transitions.length; ii += 2) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,36 @@ export type TimeZone =
   'Europe/London' |
   'US/Eastern' |
   'US/Pacific' |
-  'UTC';
+  'UTC' |
+  'Etc/GMT+12' |
+  'Etc/GMT+11' |
+  'Etc/GMT+10' |
+  'Etc/GMT+9' |
+  'Etc/GMT+8' |
+  'Etc/GMT+7' |
+  'Etc/GMT+6' |
+  'Etc/GMT+5' |
+  'Etc/GMT+4' |
+  'Etc/GMT+3' |
+  'Etc/GMT+2' |
+  'Etc/GMT+1' |
+  'Etc/GMT+0' |
+  'Etc/GMT' |
+  'Etc/GMT-0' |
+  'Etc/GMT-1' |
+  'Etc/GMT-2' |
+  'Etc/GMT-3' |
+  'Etc/GMT-4' |
+  'Etc/GMT-5' |
+  'Etc/GMT-6' |
+  'Etc/GMT-7' |
+  'Etc/GMT-8' |
+  'Etc/GMT-9' |
+  'Etc/GMT-10' |
+  'Etc/GMT-11' |
+  'Etc/GMT-12' |
+  'Etc/GMT-13' |
+  'Etc/GMT-14';
 
 export function options(options: Options): void;
 export function register(zone: TimeZone, glob?: DateHoldingGlobal): void;

--- a/lib/tzdata.js
+++ b/lib/tzdata.js
@@ -679,4 +679,207 @@ module.exports = {
       2138200200, 10.5,
     ],
   },
+  'Etc/GMT+12': {
+    names: [-12, '-12'],
+    transitions: [
+      0, -12,
+      Infinity, -12,
+    ],
+  },
+  'Etc/GMT+11': {
+    names: [-11, '-11'],
+    transitions: [
+      0, -11,
+      Infinity, -11,
+    ],
+  },
+  'Etc/GMT+10': {
+    names: [-10, '-10'],
+    transitions: [
+      0, -10,
+      Infinity, -10,
+    ],
+  },
+  'Etc/GMT+9': {
+    names: [-9, '-09'],
+    transitions: [
+      0, -9,
+      Infinity, -9,
+    ],
+  },
+  'Etc/GMT+8': {
+    names: [-8, '-08'],
+    transitions: [
+      0, -8,
+      Infinity, -8,
+    ],
+  },
+  'Etc/GMT+7': {
+    names: [-7, '-07'],
+    transitions: [
+      0, -7,
+      Infinity, -7,
+    ],
+  },
+  'Etc/GMT+6': {
+    names: [-6, '-06'],
+    transitions: [
+      0, -6,
+      Infinity, -6,
+    ],
+  },
+  'Etc/GMT+5': {
+    names: [-5, '-05'],
+    transitions: [
+      0, -5,
+      Infinity, -5,
+    ],
+  },
+  'Etc/GMT+4': {
+    names: [-4, '-04'],
+    transitions: [
+      0, -4,
+      Infinity, -4,
+    ],
+  },
+  'Etc/GMT+3': {
+    names: [-3, '-03'],
+    transitions: [
+      0, -3,
+      Infinity, -3,
+    ],
+  },
+  'Etc/GMT+2': {
+    names: [-2, '-02'],
+    transitions: [
+      0, -2,
+      Infinity, -2,
+    ],
+  },
+  'Etc/GMT+1': {
+    names: [-1, '-01'],
+    transitions: [
+      0, -1,
+      Infinity, -1,
+    ],
+  },
+  'Etc/GMT+0': {
+    names: [0, 'GMT'],
+    transitions: [
+      0, 0,
+      Infinity, 0,
+    ],
+  },
+  'Etc/GMT': {
+    names: [0, 'GMT'],
+    transitions: [
+      0, 0,
+      Infinity, 0,
+    ],
+  },
+  'Etc/GMT-0': {
+    names: [0, 'GMT'],
+    transitions: [
+      0, 0,
+      Infinity, 0,
+    ],
+  },
+  'Etc/GMT-1': {
+    names: [1, '+01'],
+    transitions: [
+      0, 1,
+      Infinity, 1,
+    ],
+  },
+  'Etc/GMT-2': {
+    names: [2, '+02'],
+    transitions: [
+      0, 2,
+      Infinity, 2,
+    ],
+  },
+  'Etc/GMT-3': {
+    names: [3, '+03'],
+    transitions: [
+      0, 3,
+      Infinity, 3,
+    ],
+  },
+  'Etc/GMT-4': {
+    names: [4, '+04'],
+    transitions: [
+      0, 4,
+      Infinity, 4,
+    ],
+  },
+  'Etc/GMT-5': {
+    names: [5, '+05'],
+    transitions: [
+      0, 5,
+      Infinity, 5,
+    ],
+  },
+  'Etc/GMT-6': {
+    names: [6, '+06'],
+    transitions: [
+      0, 6,
+      Infinity, 6,
+    ],
+  },
+  'Etc/GMT-7': {
+    names: [7, '+07'],
+    transitions: [
+      0, 7,
+      Infinity, 7,
+    ],
+  },
+  'Etc/GMT-8': {
+    names: [8, '+08'],
+    transitions: [
+      0, 8,
+      Infinity, 8,
+    ],
+  },
+  'Etc/GMT-9': {
+    names: [9, '+09'],
+    transitions: [
+      0, 9,
+      Infinity, 9,
+    ],
+  },
+  'Etc/GMT-10': {
+    names: [10, '+10'],
+    transitions: [
+      0, 10,
+      Infinity, 10,
+    ],
+  },
+  'Etc/GMT-11': {
+    names: [11, '+11'],
+    transitions: [
+      0, 11,
+      Infinity, 11,
+    ],
+  },
+  'Etc/GMT-12': {
+    names: [12, '+12'],
+    transitions: [
+      0, 12,
+      Infinity, 12,
+    ],
+  },
+  'Etc/GMT-13': {
+    names: [13, '+13'],
+    transitions: [
+      0, 13,
+      Infinity, 13,
+    ],
+  },
+  'Etc/GMT-14': {
+    names: [14, '+14'],
+    transitions: [
+      0, 14,
+      Infinity, 14,
+    ],
+  },
 };


### PR DESCRIPTION
I added all of the static GMT offsets, so that it's easier to test specific times, and things like checking for what local calendar day a date is on.

I also updated the import script to automatically add the two required transitions when importing timezones that don't have transitions, and I also updated it to add a blank line and the timezone key before the JSON object that is output by the script, making it a little easier to copy into the timezone file (and less likely for errors). As an example for `Etc/GMT-14`, the script output would be:

```

  'Etc/GMT-14': {
    names: [14, '+14'],
    transitions: [
      0, 14,
      Infinity, 14,
    ],
  },
```