### PR TITLE
Preserve explicit timeZone option in string methods

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -373,7 +373,6 @@
     "prefer-const": "off",
     "prefer-destructuring": "off",
     "prefer-numeric-literals": "error",
-    "prefer-object-spread": "error",
     "prefer-promise-reject-errors": "error",
     "prefer-reflect": "off", // JE
     "prefer-rest-params": "off",

--- a/index.js
+++ b/index.js
@@ -216,32 +216,29 @@ MockDate.prototype.toDateString = function () {
 };
 
 MockDate.prototype.toLocaleString = function (locales, options) {
-  options = options || {};
+  options = Object.assign({ timeZone: timezone }, options);
   var time = this.d.getTime();
   if (Number.isNaN(time)) {
     return new _Date('').toDateString();
   }
-  options.timeZone = timezone;
   return new _Date(time).toLocaleString(locales, options);
 };
 
 MockDate.prototype.toLocaleDateString = function (locales, options) {
-  options = options || {};
+  options = Object.assign({ timeZone: timezone }, options);
   var time = this.d.getTime();
   if (Number.isNaN(time)) {
     return new _Date('').toDateString();
   }
-  options.timeZone = timezone;
   return new _Date(time).toLocaleDateString(locales, options);
 };
 
 MockDate.prototype.toLocaleTimeString = function (locales, options) {
-  options = options || {};
+  options = Object.assign({ timeZone: timezone }, options);
   var time = this.d.getTime();
   if (Number.isNaN(time)) {
     return new _Date('').toDateString();
   }
-  options.timeZone = timezone;
   return new _Date(time).toLocaleTimeString(locales, options);
 };
 

--- a/tests/test-constructors.js
+++ b/tests/test-constructors.js
@@ -150,6 +150,12 @@ test('toLocaleString() works', function() {
   timezone_mock.register('Australia/Adelaide');
   assert.equal('May 27, 2017, 3:22 AM', new Date('2017-05-26T17:52:35.869Z').toLocaleString('en-US', options));
   timezone_mock.unregister();
+  timezone_mock.register('Australia/Adelaide');
+  const optionsWithTz = {
+    year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric', timeZone: 'UTC'
+  };
+  assert.equal('May 26, 2017, 5:52 PM', new Date('2017-05-26T17:52:35.869Z').toLocaleString('en-US', optionsWithTz));
+  timezone_mock.unregister();
 });
 
 //////////////////////////////////////////////////////////////////////////
@@ -166,6 +172,12 @@ test('toLocaleDateString() works', function() {
   timezone_mock.register('Australia/Adelaide');
   assert.equal('May 27, 2017', new Date('2017-05-26T17:52:35.869Z').toLocaleDateString('en-US', options));
   timezone_mock.unregister();
+  timezone_mock.register('Australia/Adelaide');
+  const optionsWithTz = {
+    year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC'
+  };
+  assert.equal('May 26, 2017', new Date('2017-05-26T17:52:35.869Z').toLocaleDateString('en-US', optionsWithTz));
+  timezone_mock.unregister();
 });
 
 //////////////////////////////////////////////////////////////////////////
@@ -178,5 +190,8 @@ test('toLocaleTimeString() works', function() {
   timezone_mock.unregister();
   timezone_mock.register('Australia/Adelaide');
   assert.equal('3:22:35 AM', new Date('2017-05-26T17:52:35.869Z').toLocaleTimeString('en-US'));
+  timezone_mock.unregister();
+  timezone_mock.register('Australia/Adelaide');
+  assert.equal('5:52:35 PM', new Date('2017-05-26T17:52:35.869Z').toLocaleTimeString('en-US', { timeZone: 'UTC' }));
   timezone_mock.unregister();
 });


### PR DESCRIPTION
Builds upon the string options implemented in #54 to ensure that if an explicit timeZone option is passed, it is used in place of the default mocked value.