### PR TITLE
Feature/add additional time formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ var date_iso_8601_regex = /^\d\d\d\d(-\d\d(-\d\d(T\d\d:\d\d:\d\d(\.\d\d\d)?(\d\d
 var date_with_offset = /^\d\d\d\d-\d\d-\d\d( \d\d:\d\d:\d\d(\.\d\d\d)? )?(Z|(-|\+|)\d\d:\d\d)$/;
 var date_rfc_2822_regex = /^\d\d-\w\w\w-\d\d\d\d \d\d:\d\d:\d\d (\+|-)\d\d\d\d$/;
 var local_date_regex = /^\d\d\d\d-\d\d-\d\d[T ]\d\d:\d\d(:\d\d(\.\d\d\d)?)?$/;
+var local_GMT_regex = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d\d \w\w\w \d\d\d\d \d\d:\d\d:\d\d GMT$/
 
 function MockDate(param) {
   if (arguments.length === 0) {
@@ -31,6 +32,7 @@ function MockDate(param) {
       if (param.match(date_iso_8601_regex) ||
         param.match(date_with_offset) ||
         param.match(date_rfc_2822_regex) ||
+        param.match(local_GMT_regex) ||
         param === ''
       ) {
         this.d = new _Date(param);

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sept', 'O
 var HOUR = 60 * 60 * 1000;
 
 var date_iso_8601_regex = /^\d\d\d\d(-\d\d(-\d\d(T\d\d:\d\d:\d\d(\.\d\d\d)?(\d\d\d)?(Z|[+-]\d\d:?\d\d))?)?)?$/;
-var date_with_offset = /^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d\d\d)? (Z|(-|\+|)\d\d:\d\d)$/;
+var date_with_offset = /^\d\d\d\d-\d\d-\d\d( \d\d:\d\d:\d\d(\.\d\d\d)? )?(Z|(-|\+|)\d\d:\d\d)$/;
 var date_rfc_2822_regex = /^\d\d-\w\w\w-\d\d\d\d \d\d:\d\d:\d\d (\+|-)\d\d\d\d$/;
 var local_date_regex = /^\d\d\d\d-\d\d-\d\d[T ]\d\d:\d\d(:\d\d(\.\d\d\d)?)?$/;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "timezone-mock",
-  "version": "1.2.1",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/test-constructors.js
+++ b/tests/test-constructors.js
@@ -101,6 +101,17 @@ test('constructor supports time format YYYY-MM-DDZ', function() {
   timezone_mock.unregister();
 });
 
+/////////////////////////////////
+test('constructor supports time format Fri, 27 Jul 2019 10:32:24 GMT', function() {
+  timezone_mock.register('UTC');
+  assert.equal(new Date('Fri, 27 Jul 2019 10:32:24 GMT').toLocaleString('en-US'), '7/27/2019, 10:32:24 AM');
+  assert.throws(() => new Date('Fre, 27 Jul 2019 10:32:24 GMT').toLocaleString('en-US'));
+  timezone_mock.unregister();
+  timezone_mock.register('US/Pacific');
+  assert.equal(new Date('Fri, 27 Jul 2019 10:32:24 GMT').toLocaleString('en-US'), '7/27/2019, 3:32:24 AM');
+  timezone_mock.unregister();
+});
+
 //////////////////////////////////////////////////////////////////////////
 test('UTC/non-local timezone constructors', function() {
   assert.equal(1495821155869, new Date('2017-05-26T17:52:35.869Z').getTime());

--- a/tests/test-constructors.js
+++ b/tests/test-constructors.js
@@ -88,6 +88,19 @@ test('date constructors as used by local timezone mode in node-mysql (local stri
   assert.equal(1414915200000, new Date('2014-11-02T01:00').getTime());
 });
 
+/////////////////////////////////
+test('constructor supports time format YYYY-MM-DDZ', function() {
+  timezone_mock.register('UTC');
+  assert.equal(new Date('2017-05-26Z').toLocaleTimeString('en-US'), '12:00:00 AM');
+  assert.equal(new Date('2017-05-26Z').toLocaleDateString('en-US'), '5/26/2017');
+  assert.throws(() => new Date('2017-05-26X').toLocaleTimeString('en-US'));
+  timezone_mock.unregister();
+  timezone_mock.register('US/Pacific');
+  assert.equal(new Date('2017-05-26Z').toLocaleTimeString('en-US'), '5:00:00 PM');
+  assert.equal(new Date('2017-05-26Z').toLocaleDateString('en-US'), '5/25/2017');
+  timezone_mock.unregister();
+});
+
 //////////////////////////////////////////////////////////////////////////
 test('UTC/non-local timezone constructors', function() {
   assert.equal(1495821155869, new Date('2017-05-26T17:52:35.869Z').getTime());
@@ -135,7 +148,7 @@ test('option to use a fallback function when failing to parse (issue #24)', func
     fallbackFn: (date) => new _Date(date)
   });
   timezone_mock.register('UTC');
-  assert.equal(new Date('Fri, 26 Jul 2019 10:32:24 GMT').toDateString(), 'Fri Jul 26 2019');
+  assert.equal(new Date('Fri, 26 Jul 2019 10:32:24 GMT-1').toDateString(), 'Fri Jul 26 2019');
   timezone_mock.unregister();
 
   // How can we reset options?
@@ -143,7 +156,7 @@ test('option to use a fallback function when failing to parse (issue #24)', func
   timezone_mock.register('UTC');
   var got_error = false;
   try {
-    assert.equal(new Date('Fri, 26 Jul 2019 10:32:24 GMT').toDateString(), 'Fri Jul 26 2019');
+    assert.equal(new Date('Fri, 26 Jul 2019 10:32:24 GMT-1').toDateString(), 'Fri Jul 26 2019');
   } catch (err) {
     // Expected
     got_error = true;


### PR DESCRIPTION
Hi @Jimbly,

we, the Hackergarten group from Stuttgart, added support for two more formats, that the original Date object supports..
One is the format `YYYY-MM-DDZ` with an additional Z for Zulu time and the other is `Fri, 27 Jul 2019 10:32:24 GMT` is it was requested in #24
Please have a look and let me know if you need anything more to merge this.

closes #24 

