### PR TITLE
Support YYYY-MM-DDThh:mmZ in constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sept', 'O
 
 var HOUR = 60 * 60 * 1000;
 
-var date_iso_8601_regex = /^\d\d\d\d(-\d\d(-\d\d(T\d\d:\d\d:\d\d(\.\d\d\d)?(\d\d\d)?(Z|[+-]\d\d:?\d\d))?)?)?$/;
+var date_iso_8601_regex = /^\d\d\d\d(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d\d\d)?(\d\d\d)?(Z|[+-]\d\d:?\d\d))?)?)?$/;
 var date_with_offset = /^\d\d\d\d-\d\d-\d\d( \d\d:\d\d:\d\d(\.\d\d\d)? )?(Z|(-|\+|)\d\d:\d\d)$/;
 var date_rfc_2822_regex = /^\d\d-\w\w\w-\d\d\d\d \d\d:\d\d:\d\d (\+|-)\d\d\d\d$/;
 var local_date_regex = /^\d\d\d\d-\d\d-\d\d[T ]\d\d:\d\d(:\d\d(\.\d\d\d)?)?$/;

--- a/tests/test-constructors.js
+++ b/tests/test-constructors.js
@@ -102,6 +102,19 @@ test('constructor supports time format YYYY-MM-DDZ', function() {
 });
 
 /////////////////////////////////
+test('constructor supports time format YYYY-MM-DDThh:mmZ', function() {
+  timezone_mock.register('UTC');
+  assert.equal(new Date('2017-05-26T00:00Z').toLocaleTimeString('en-US'), '12:00:00 AM');
+  assert.equal(new Date('2017-05-26T00:00Z').toLocaleDateString('en-US'), '5/26/2017');
+  assert.throws(() => new Date('2017-05-26T00:00:Z').toLocaleTimeString('en-US'));
+  timezone_mock.unregister();
+  timezone_mock.register('US/Pacific');
+  assert.equal(new Date('2017-05-26T00:00Z').toLocaleTimeString('en-US'), '5:00:00 PM');
+  assert.equal(new Date('2017-05-26T00:00Z').toLocaleDateString('en-US'), '5/25/2017');
+  timezone_mock.unregister();
+});
+
+/////////////////////////////////
 test('constructor supports time format Fri, 27 Jul 2019 10:32:24 GMT', function() {
   timezone_mock.register('UTC');
   assert.equal(new Date('Fri, 27 Jul 2019 10:32:24 GMT').toLocaleString('en-US'), '7/27/2019, 10:32:24 AM');


### PR DESCRIPTION
Added support for one more formats, that the original Date object supports.
The format is YYYY-MM-DDThh:mmZ
Please have a look and let me know if you need anything more to merge this.
similar #63 

closes #64 