### PR TITLE
Eliminate need for Node assert in browser tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
 'use strict';
 
-var assert = require('assert');
+var assert = {
+  ok(cond, msg) {
+    if (!cond) {
+      throw new Error(msg);
+    }
+  }
+};
+
 var tzdata = require('./lib/tzdata.js');
 exports.tzdata = tzdata;
 
@@ -85,7 +92,7 @@ function passthrough(fn) {
       // there should be no _Date objects in user code when using MockDate.
       real_date = this;
     } else {
-      assert(false, 'Unexpected object type');
+      assert.ok(false, 'Unexpected object type');
     }
     return real_date[fn].apply(real_date, arguments);
   };
@@ -292,7 +299,7 @@ function unregister(glob) {
     }
   }
   if (glob.Date === MockDate) {
-    assert(_Date);
+    assert.ok(_Date, 'need to pass a date');
     glob.Date = _Date;
   }
 }


### PR DESCRIPTION
Howdy, I'm upgrading a client app from Webpack 4 -> 5 (yes, I know it's old). As part of that, we hit the below wrinkle with `timezone-mock`:

```
ERROR in ./node_modules/.pnpm/timezone-mock@1.3.1/node_modules/timezone-mock/index.js 1:24-41
Module not found: Error: Can't resolve 'assert' in '/home/circleci/project/node_modules/.pnpm/timezone-mock@1.3.1/node_modules/timezone-mock'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "assert": require.resolve("assert/") }'
	- install 'assert'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "assert": false }
resolve 'assert' in '/home/circleci/project/node_modules/.pnpm/timezone-mock@1.3.1/node_modules/timezone-mock'
  Parsed request is a module
  using description file: /home/circleci/project/node_modules/.pnpm/timezone-mock@1.3.1/node_modules/timezone-mock/package.json (relative path: .)
```

It turns out the polyfill for `assert` is relatively heavy in a browser context and `assert` usage here was pretty minimal. So thought I'd send this over as a possible fix. I can add better comments or a test to check in a browser context if desired, but thought I'd check to see if you were at all interested in the change.

Thanks for your work on this!