### PR TITLE
Fix setDate/setMonth overflow clamping the year back (#82, #83)

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,9 +210,18 @@ MockDate.prototype.fromLocal = function () {
     offsets.reduce(function (acc, o) {
       var bestTs = acc[0];
       var correctOffset = acc[1];
-      var ts = new _Date(
-        _Date.UTC.apply(null, localComponents)
-      ).setUTCFullYear(localComponents[0]) - (o * HOUR);
+      // Date.UTC() maps years 0-99 to 1900-1999, so we must force the literal
+      // year back onto the result in that ambiguous range. For years >= 100 we
+      // must NOT do this: day/month overflow that legitimately advances the
+      // year (e.g. setDate(getDate() + N) / setMonth(getMonth() + N), as
+      // date-fns addDays/addMonths do) would otherwise be clamped back to the
+      // pre-overflow year, producing a result one or more years off.
+      // See https://github.com/Jimbly/timezone-mock/issues/82 and #83.
+      var utc = new _Date(_Date.UTC.apply(null, localComponents));
+      if (localComponents[0] >= 0 && localComponents[0] < 100) {
+        utc.setUTCFullYear(localComponents[0]);
+      }
+      var ts = utc.getTime() - (o * HOUR);
       if (-mockDate.calcTZO(ts) === o) {
         return [correctOffset === false || ts < bestTs ? ts : bestTs, true];
       }

--- a/tests/test-setters.js
+++ b/tests/test-setters.js
@@ -241,7 +241,17 @@ const cases = [
   // For very old dates, Node uses mean solar time in Los Angeles
   // rather than US standard times. timezone_mock does not emulate this,
   // so we are expecting to be off by 422 seconds here.
-  ['US/Pacific', '1970-01-01T00:00:00Z'     , 'setFullYear',   20, -61504445222000 + 422000 ]
+  ['US/Pacific', '1970-01-01T00:00:00Z'     , 'setFullYear',   20, -61504445222000 + 422000 ],
+
+  // setDate()/setMonth() overflow that legitimately advances the year must not
+  // be clamped back to the pre-overflow year when the mock TZ and the literal
+  // UTC components fall in different years. Regressions reported in #82 and #83
+  // (date-fns addDays/addMonths roll the year via these overflowing setters).
+  // Local start is 2022-12-31 16:00 PST, so getDate() === 31 / getMonth() === 11.
+  ['US/Pacific', '2023-01-01T00:00:00Z', 'setDate', 131, '2023-04-10T23:00:00Z'], // #82: setDate(getDate()+100), year must advance to 2023
+  ['US/Pacific', '2023-01-01T00:00:00Z', 'setDate',  54, '2023-01-24T00:00:00Z'], // #83: setDate(getDate()+23), crosses into 2023
+  ['US/Pacific', '2023-01-01T00:00:00Z', 'setMonth', 12, '2023-02-01T00:00:00Z'], // setMonth overflow rolls Dec 2022 -> Jan 2023, year must advance
+  ['UTC',        '2025-01-15T00:00:00Z', 'setDate',  -1, '2024-12-30T00:00:00Z']  // #83: negative overflow rolls back into the previous year
 ];
 
 for (const c of cases) {


### PR DESCRIPTION
## Summary

`fromLocal()` applied `setUTCFullYear(localComponents[0])` **unconditionally** (added in #81 to handle two-digit-year ambiguity, since `Date.UTC()` maps years 0–99 to 1900–1999). But when day/month **overflow** is the intended mechanism to advance the year — exactly what `date-fns` `addDays`/`addMonths` do via `setDate(getDate() + N)` / `setMonth(getMonth() + N)` — the unconditional clamp snaps the year back, producing a result one or more years off whenever the mock timezone and the literal UTC components fall in different years.

Fixes #83 and #82 (and likely the long-standing #56).

## Root cause

For mock `US/Pacific`, `new Date('2023-01-01T00:00:00Z')` is locally `2022-12-31 16:00 PST`, so `getDate()` is `31` / `getMonth()` is `11` / `getFullYear()` is `2022`. A `setDate(getDate() + 100)` → `setDate(131)`:

1. `localsetter` builds `dateArgs = [2022, 11, 131]`.
2. `Date.UTC(2022, 11, 131, …)` correctly overflows forward to **2023**-04-10.
3. `.setUTCFullYear(2022)` then snaps the year back to **2022**-04-10 — wrong by one year.

```js
// before: 2022-04-10T23:00:00.000Z  ❌
// after:  2023-04-10T23:00:00.000Z  ✅ (matches native Date)
```

## Fix

Only force the literal year in the genuinely ambiguous `0–99` range; for years `>= 100`, let `Date.UTC()`'s natural overflow stand. This keeps the #80/#81 two-digit-year behavior intact while no longer clobbering legitimate year advancement.

## Tests

Adds regression cases to `tests/test-setters.js` (the existing data-driven `cases` table):

- `US/Pacific` `setDate(131)` — #82, year must advance to 2023
- `US/Pacific` `setDate(54)` — #83, crosses into 2023
- `US/Pacific` `setMonth(12)` — overflow rolls Dec 2022 → Jan 2023
- `UTC` `setDate(-1)` — #83 negative overflow rolls back into 2024

All expected values were taken from **native** `Date` under the matching `TZ`. Confirmed the new cases **fail** on the prior code and **pass** with this change. Full suite (`npm test`, run under `TZ=US/Pacific`) and `npm run lint` both pass.